### PR TITLE
Updated Yaml loading to use parse method (Symfony beta5 changes).

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -53,7 +53,7 @@ class GenerateCommand extends Command
             if (is_dir($dir)) {
                 $finder = new Finder();
                 foreach ($finder->files()->name('*.yml')->followLinks()->in($dir) as $file) {
-                    foreach ((array) Yaml::load($file) as $class => $configClass) {
+                    foreach ((array) Yaml::parse($file) as $class => $configClass) {
                         // class
                         if (0 !== strpos($class, 'Model\\')) {
                             throw new \RuntimeException('The Mandango documents must been in the "Model\" namespace.');
@@ -78,7 +78,7 @@ class GenerateCommand extends Command
             if (is_dir($dir = $bundle->getPath().'/Resources/config/mandango')) {
                 $finder = new Finder();
                 foreach ($finder->files()->name('*.yml')->followLinks()->in($dir) as $file) {
-                    foreach ((array) Yaml::load($file) as $class => $configClass) {
+                    foreach ((array) Yaml::parse($file) as $class => $configClass) {
                         // class
                         if (0 !== strpos($class, 'Model\\')) {
                             throw new \RuntimeException('The mandango documents must been in the "Model\" namespace.');

--- a/Command/LoadFixturesCommand.php
+++ b/Command/LoadFixturesCommand.php
@@ -83,7 +83,7 @@ class LoadFixturesCommand extends Command
 
         $data = array();
         foreach ($files as $file) {
-            $data = Util::arrayDeepMerge($data, (array) Yaml::load($file));
+            $data = Util::arrayDeepMerge($data, (array) Yaml::parse($file));
         }
 
         if (!$data) {


### PR DESCRIPTION
Symfony beta 5 renamed the Yaml::load() method to Yaml::parse() - this commit updates the MandangoBundle accordingly.
