### PR TITLE
Updated MergeGroupListener to reflect Symfony2 FormEvent changes.

### DIFF
--- a/Form/EventListener/MergeGroupListener.php
+++ b/Form/EventListener/MergeGroupListener.php
@@ -11,7 +11,7 @@
 
 namespace Mandango\MandangoBundle\Form\EventListener;
 
-use Symfony\Component\Form\Events;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -24,7 +24,7 @@ class MergeGroupListener implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
-        return Events::onBindNormData;
+        return array(FormEvents::BIND_NORM_DATA);
     }
 
     public function onBindNormData(FilterDataEvent $event)

--- a/Form/EventListener/MergeGroupListener.php
+++ b/Form/EventListener/MergeGroupListener.php
@@ -24,7 +24,7 @@ class MergeGroupListener implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::BIND_NORM_DATA);
+        return array(FormEvents::BIND_NORM_DATA => 'onBindNormData');
     }
 
     public function onBindNormData(FilterDataEvent $event)


### PR DESCRIPTION
This updates the `getSubscribedEvents()` method to return an array of events and associated methods as expected, with the event name having been updated to correspond to the FormEvents class in Symfony2.
