### PR TITLE
Adjusted doc to ID transformer to cater for empty values in choice boxes.

### DIFF
--- a/Form/DataTransformer/MandangoDocumentToIdTransformer.php
+++ b/Form/DataTransformer/MandangoDocumentToIdTransformer.php
@@ -48,6 +48,6 @@ class MandangoDocumentToIdTransformer implements DataTransformerInterface
 
         $documents = $this->choiceList->getDocuments();
 
-        return $documents[$key];
+        return array_key_exists($key, $documents) ? $documents[$key] : null;
     }
 }


### PR DESCRIPTION
This commit fixes an issue where an empty value is selected in a choice list, which resulted in the key being empty and thus a notice was thrown.  It now returns null to indicate no matched document.
